### PR TITLE
Adds source map support to webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ var webpack = require('webpack');
 var ExtractTextPlugin = require("extract-text-webpack-plugin");
 
 module.exports = {
+    devtool: "#cheap-source-map",
     entry: "./src/pages/home/client.js",
     output: {
         path: __dirname,


### PR DESCRIPTION
This change outputs source maps by using the [devtool](https://webpack.github.io/docs/configuration.html#devtool) config. I chose `cheap-source-map` but others are also possible, speed didn't seem to be a critical factor here.

## Firefox

<img width="1386" alt="screen shot 2017-06-12 at 6 01 20 pm" src="https://user-images.githubusercontent.com/2134/27061483-2eb47ff8-4f99-11e7-9904-41b17db081bf.png">

## Chrome

<img width="1245" alt="screen shot 2017-06-12 at 6 02 02 pm" src="https://user-images.githubusercontent.com/2134/27061493-44feb7b0-4f99-11e7-876e-bb083bbe5fe8.png">
